### PR TITLE
directionChange

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ### Deployment
-Currently deployed via a helm manged GKE cluster at [stephenrmason.net](http://www.stephenrmason.net)
+~~Currently deployed via a helm manged GKE cluster at [stephenrmason.net](http://www.stephenrmason.net)~~
+Above currently non-functional due to cost of continuously running multiple pods in GKE.
 
 ### Architecture
 - Basic tests are run via a github workflow [Here](https://github.com/IsNoble/Test-Pipeline-GCP/blob/main/.github/workflows/python-app.yml)
@@ -24,9 +25,11 @@ This project is purely for example/educational purposes. For a production static
 - ~~Add DNS entry that points to the LoadBalancer of k8'S SERVICE~~
 - ~~Packages K8's manifest into a Helm chart~~
 - ~~Remove (currently) redundant k8's manifest files~~
-- Add terraform code to generate bucket for static django app files
+- ~~Add terraform code to generate bucket for static django app files~~
+  - Generate static storage bucket
   - set public ACL for static storage bucket.
-- Deploy ArgoCD via helm to my cluster
+- ~~Deploy ArgoCD via helm to my cluster~~
+  - ON HOLD: argoCD testing will take place in local minikube cluster due to cost constraints. 
 - Setup and configure external DNS
 - Setup and configure CertManager
 - Setup HTTPS vis Istio Gateway

--- a/argoCD/override-values.yaml
+++ b/argoCD/override-values.yaml
@@ -1,0 +1,1 @@
+replicaCount: 0

--- a/charts/django-site/values.yaml
+++ b/charts/django-site/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 3
+replicaCount: 1
 
 image:
   repository: ghcr.io/isnoble/test-pipeline-gcp
@@ -75,9 +75,9 @@ resources: {}
   #   memory: 128Mi
 
 autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
+  enabled: true
+  minReplicas: 0
+  maxReplicas: 1
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 


### PR DESCRIPTION
### Purpose

Due to cost constraints associated with running pods in GKE. I will be deploying my application to GKE only when I am actively working on it. Thus argoCD has been cut from the roadmap for now (Testing for argoCD will be done in a local miniKube cluster). The rest of the roadmap will remain unchanged. 